### PR TITLE
chore: 🤖 fixed nextjs build error for prisma in turborepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ build/**
 dist/**
 .next/**
 dist
+
+# prisma generated client and types in packages > db
+**/lib/generated/client/**

--- a/apps/web/src/trpc/server.ts
+++ b/apps/web/src/trpc/server.ts
@@ -4,7 +4,7 @@ import { cache } from "react";
 import { cookies, headers } from "next/headers";
 import { NextRequest } from "next/server";
 import { getAuth } from "@clerk/nextjs/server";
-import { AppRouter, createTRPCContext } from "@convoform/api";
+import { createTRPCContext, type AppRouter } from "@convoform/api";
 import { appRouter } from "@convoform/api/server/api/root";
 import {
   createTRPCProxyClient,

--- a/packages/api/server/api/trpc.ts
+++ b/packages/api/server/api/trpc.ts
@@ -6,17 +6,16 @@
  * TL;DR - This is where all the tRPC server stuff is created and plugged in. The pieces you will
  * need to use are documented accordingly near the end.
  */
-import { getAuth } from "@clerk/nextjs/server";
+import { SignedInAuthObject, SignedOutAuthObject } from "@clerk/nextjs/server";
 import { prisma } from "@convoform/db";
-import { inferAsyncReturnType, initTRPC, TRPCError } from "@trpc/server";
+import { initTRPC, TRPCError } from "@trpc/server";
+import * as trpc from "@trpc/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
-type AuthObject = ReturnType<typeof getAuth>;
-
-type CreateContextOptions = {
-  auth: AuthObject;
-};
+interface AuthContext {
+  auth: SignedInAuthObject | SignedOutAuthObject;
+}
 
 /**
  * This helper generates the "internals" for a tRPC context. If you need to use
@@ -27,7 +26,7 @@ type CreateContextOptions = {
  * - trpc's `createSSGHelpers` where we don't have req/res
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */
-export const createInnerTRPCContext = (opts: CreateContextOptions) => {
+export const createInnerTRPCContext = (opts: AuthContext) => {
   return {
     ...opts,
     db: prisma,
@@ -46,10 +45,11 @@ export const createInnerTRPCContext = (opts: CreateContextOptions) => {
  *
  * @see https://trpc.io/docs/server/context
  */
-export const createTRPCContext = async (opts: {
-  headers: Headers;
-  auth: AuthObject;
-}) => {
+export const createTRPCContext = async (
+  opts: AuthContext & {
+    headers: Headers;
+  },
+) => {
   const innerContext = createInnerTRPCContext({
     auth: opts.auth,
   });
@@ -60,7 +60,7 @@ export const createTRPCContext = async (opts: {
   };
 };
 
-export type Context = inferAsyncReturnType<typeof createTRPCContext>;
+export type Context = trpc.inferAsyncReturnType<typeof createTRPCContext>;
 
 /**
  * 2. INITIALIZATION
@@ -109,11 +109,11 @@ export const publicProcedure = t.procedure;
 
 /** Reusable middleware that enforces users are logged in before running the procedure. */
 const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
-  if (!ctx.userId) {
+  if (!ctx.auth?.userId) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
   // Make ctx.userId non-nullable in protected procedures
-  return next({ ctx: { userId: ctx.userId } });
+  return next({ ctx: { userId: ctx.auth.userId, auth: ctx.auth } });
 });
 
 /**

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,11 +1,8 @@
 {
   "name": "@convoform/db",
   "version": "0.0.0",
-  "main": "./index.ts",
-  "types": "./index.ts",
-  "exports": {
-    ".": "./index.ts"
-  },
+  "private": true,
+  "main": "index.ts",
   "scripts": {
     "studio": "prisma studio",
     "reset-db": "prisma migrate reset",

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  output   = "../lib/generated/client"
 }
 
 datasource db {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "../lib/generated/client";
 
 const prismaClientSingleton = () => {
   return new PrismaClient();
@@ -17,4 +17,4 @@ if (process.env.NODE_ENV !== "production") {
   globalThis.prisma = prisma;
 }
 
-export * from "@prisma/client";
+export * from "../lib/generated/client";

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,14 +1,4 @@
 {
-  "compilerOptions": {
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "preserveWatchOutput": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "strict": true
-  },
-  "exclude": ["node_modules"]
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
 }


### PR DESCRIPTION
web:build: Type error: The inferred type of 'api' cannot be named without a reference to
'../../../../packages/db/node_modules/@prisma/client/runtime/library'. This is likely not portable. A type annotation is necessary.