### PR TITLE
fix: 🐛 Prisma client not working on production

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,4 +1,5 @@
 import createMDX from "@next/mdx";
+import { PrismaPlugin } from "@prisma/nextjs-monorepo-workaround-plugin";
 // Injected content via Sentry wizard below
 
 import { withSentryConfig } from "@sentry/nextjs";
@@ -26,6 +27,13 @@ const nextConfig = {
   // Configure `pageExtensions` to include MDX files
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
   transpilePackages: ["@convoform/ui", "@convoform/db"],
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.plugins = [...config.plugins, new PrismaPlugin()];
+    }
+
+    return config;
+  },
 };
 
 const withMDX = createMDX({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,14 +43,16 @@
     "react-dom": "^18",
     "react-hook-form": "^7.48.2",
     "remark-gfm": "^4.0.0",
+    "superjson": "^2.2.1",
     "tailwind-merge": "^2.0.0",
-    "zod": "^3.22.4",
-    "superjson": "^2.2.1"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@convoform/eslint-config": "workspace:*",
     "@convoform/tsconfig": "workspace:*",
+    "@prisma/nextjs-monorepo-workaround-plugin": "^5.9.0",
     "@swc-jotai/react-refresh": "^0.1.0",
+    "@tanstack/react-query-devtools": "^5.17.21",
     "@types/node": "^20",
     "@types/nprogress": "^0.2.3",
     "@types/react": "^18",
@@ -62,7 +64,6 @@
     "eslint-plugin-unused-imports": "^3.0.0",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5",
-    "@tanstack/react-query-devtools": "^5.17.21"
+    "typescript": "^5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       "@convoform/tsconfig":
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      "@prisma/nextjs-monorepo-workaround-plugin":
+        specifier: ^5.9.0
+        version: 5.9.0
       "@swc-jotai/react-refresh":
         specifier: ^0.1.0
         version: 0.1.0
@@ -1940,6 +1943,13 @@ packages:
       }
     dependencies:
       "@prisma/debug": 5.8.1
+
+  /@prisma/nextjs-monorepo-workaround-plugin@5.9.0:
+    resolution:
+      {
+        integrity: sha512-++aY/BdZFbVMUvpFb+kyXSmFKGlFbyKCeR296hHfeokuIxnit9V4hVdRZbEzkGxza5d4bn/3UYbqhMatkMkHFQ==,
+      }
+    dev: true
 
   /@radix-ui/number@1.0.1:
     resolution:


### PR DESCRIPTION
After build success, prisma client error at runtime, Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x".

✅ Closes: #173