### PR TITLE
fix: 🐛 edge case where collected data value is not string

### DIFF
--- a/apps/web/src/app/(protectedPage)/forms/[formId]/conversations/_components/conversationDetail.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/conversations/_components/conversationDetail.tsx
@@ -49,6 +49,20 @@ export default function ConversationDetail({ conversation }: Props) {
               <Table className="">
                 <TableBody>
                   {formFieldsDataKeys.map((key) => {
+                    // Handled edge case where field value is not string but object
+                    formFieldsDataKeys.forEach((key) => {
+                      const formValue = formFieldsData[key];
+                      if (!formValue) return;
+                      const valueType = typeof formValue;
+                      if (valueType !== "string") {
+                        if (valueType === "object") {
+                          formFieldsData[key] =
+                            Object.values(formValue).join(", ");
+                          return;
+                        }
+                        formFieldsData[key] = JSON.stringify(formValue);
+                      }
+                    });
                     return (
                       <TableRow key={formFieldsData[key]}>
                         <TableCell className="py-2">{key}</TableCell>

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/conversations/_components/overviewTable.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/conversations/_components/overviewTable.tsx
@@ -18,11 +18,27 @@ export function OverviewTable({ formId }: Readonly<Props>) {
     <QueryTable
       query={query}
       getTableData={(data) => {
-        return data.map((item) => ({
-          ["Created"]: item.createdAt.toLocaleString(),
-          ["Response name"]: item.name,
-          ...item.formFieldsData,
-        }));
+        return data.map((item) => {
+          // Handled edge case where field value is not string but object
+          Object.keys(item.formFieldsData).forEach((key) => {
+            const formValue = item.formFieldsData[key];
+            if (!formValue) return;
+            const valueType = typeof formValue;
+            if (valueType !== "string") {
+              if (valueType === "object") {
+                item.formFieldsData[key] = Object.values(formValue).join(", ");
+                return;
+              }
+              item.formFieldsData[key] = JSON.stringify(formValue);
+            }
+          });
+
+          return {
+            ["Created"]: item.createdAt.toLocaleString(),
+            ["Response name"]: item.name,
+            ...item.formFieldsData,
+          };
+        });
       }}
       showExportButton
       exportFileName={exportFileName}


### PR DESCRIPTION
If the collected field value is not string but object, It break the page because react try to render the object as string