### PR TITLE
style: 💄 New form editor layout

### DIFF
--- a/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/customizeEndingScreen.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/customizeEndingScreen.tsx
@@ -1,0 +1,3 @@
+export function CustomizeEndingScreenCard() {
+  return <div className="text-muted-foreground text-xl">Coming soon</div>;
+}

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/customizeLandingScreen.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/customizeLandingScreen.tsx
@@ -1,0 +1,3 @@
+export function CustomizeLandingScreenCard() {
+  return <div className="text-muted-foreground text-xl">Coming soon</div>;
+}

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/customizePage.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/customizePage.tsx
@@ -1,0 +1,3 @@
+export function CustomizePageCard() {
+  return <div className="text-muted-foreground text-xl">Coming soon</div>;
+}

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/customizeQuestionsScreen.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/customizeQuestionsScreen.tsx
@@ -1,0 +1,3 @@
+export function CustomizeQuestionsScreenCard() {
+  return <div className="text-muted-foreground text-xl">Coming soon</div>;
+}

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/index.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formCustomizeSection/index.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useFormEditor } from "../formEditorContext";
+import { CustomizeEndingScreenCard } from "./customizeEndingScreen";
+import { CustomizeLandingScreenCard } from "./customizeLandingScreen";
+import { CustomizePageCard } from "./customizePage";
+import { CustomizeQuestionsScreenCard } from "./customizeQuestionsScreen";
+
+export function FormCustomizeSection() {
+  const { currentSection } = useFormEditor();
+  const renderSection = () => {
+    switch (currentSection) {
+      case "landing-screen":
+        return <CustomizeLandingScreenCard />;
+      case "questions-screen":
+        return <CustomizeQuestionsScreenCard />;
+      case "ending-screen":
+        return <CustomizeEndingScreenCard />;
+      case "customize-page":
+        return <CustomizePageCard />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div>
+      <div className="font-medium text-lg mb-4">Design</div>
+      {renderSection()}
+    </div>
+  );
+}

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formEditor/formEditorCard.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formEditor/formEditorCard.tsx
@@ -38,6 +38,11 @@ import { isRateLimitErrorResponse } from "@/lib/errorHandlers";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 import { Label } from "@convoform/ui/components/ui/label";
+import {
+  FORM_EDITOR_SECTIONS_ENUMS,
+  defaultFormEditorSection,
+  useFormEditor,
+} from "../formEditorContext";
 import { CustomizeEndScreenCard } from "./customizeEndScreenCard";
 import { CustomizeFormCard } from "./customizeFormCard";
 import { FieldsEditorCard } from "./fieldsEditorCard";
@@ -76,6 +81,8 @@ export function FormEditorCard({ form, organization }: Readonly<Props>) {
       fieldsOrders: getSafeFormFieldsOrders(form, form.formFields),
     }));
   }, [form.formFields]);
+
+  const { setCurrentSection } = useFormEditor();
 
   const queryClient = useQueryClient();
   const updateForm = api.form.updateForm.useMutation({
@@ -161,9 +168,13 @@ export function FormEditorCard({ form, organization }: Readonly<Props>) {
         type="single"
         collapsible
         className="w-full"
-        defaultValue="overview"
+        defaultValue={defaultFormEditorSection}
+        onValueChange={setCurrentSection}
       >
-        <AccordionItem value="landing-page-fields" className="border-b-muted">
+        <AccordionItem
+          value={FORM_EDITOR_SECTIONS_ENUMS.landingScreen}
+          className="border-b-muted"
+        >
           <AccordionTrigger
             className={cn(
               "text-muted-foreground group font-medium hover:text-black hover:no-underline data-[state=open]:text-black",
@@ -239,7 +250,10 @@ export function FormEditorCard({ form, organization }: Readonly<Props>) {
           </UIForm>
         </AccordionItem>
 
-        <AccordionItem value="requirement-fields" className="border-b-muted">
+        <AccordionItem
+          value={FORM_EDITOR_SECTIONS_ENUMS.questionsScreen}
+          className="border-b-muted"
+        >
           <AccordionTrigger
             className={cn(
               "text-muted-foreground group font-medium  hover:text-black hover:no-underline data-[state=open]:text-black",
@@ -297,7 +311,10 @@ export function FormEditorCard({ form, organization }: Readonly<Props>) {
             </div>
           </AccordionContent>
         </AccordionItem>
-        <AccordionItem value="ending-page" className="border-none">
+        <AccordionItem
+          value={FORM_EDITOR_SECTIONS_ENUMS.endingScreen}
+          className="border-none"
+        >
           <AccordionTrigger
             className={cn(
               "text-muted-foreground group font-medium  hover:text-black hover:no-underline data-[state=open]:text-black",
@@ -317,7 +334,10 @@ export function FormEditorCard({ form, organization }: Readonly<Props>) {
             <CustomizeEndScreenCard form={form} />
           </AccordionContent>
         </AccordionItem>
-        <AccordionItem value="customize-page" className="border-none">
+        <AccordionItem
+          value={FORM_EDITOR_SECTIONS_ENUMS.customizePage}
+          className="border-none"
+        >
           <AccordionTrigger
             className={cn(
               "text-muted-foreground group font-medium  hover:text-black hover:no-underline data-[state=open]:text-black",

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formEditorContext.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/_components/formEditorContext.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+type FormEditorContextType = {
+  currentSection: FormEditorSections | null;
+  currentField: string | null;
+  setCurrentSection: (section: FormEditorSections) => void;
+  setCurrentField: (field: string) => void;
+};
+
+const FormEditorContext = createContext<FormEditorContextType | undefined>(
+  undefined,
+);
+
+export function FormEditorProvider({
+  children,
+}: { children: React.ReactNode }) {
+  const [currentSection, setCurrentSection] = useState<
+    FormEditorContextType["currentSection"]
+  >(defaultFormEditorSection);
+  const [currentField, setCurrentField] =
+    useState<FormEditorContextType["currentField"]>(null);
+  return (
+    <FormEditorContext.Provider
+      value={{
+        currentSection,
+        currentField,
+        setCurrentSection,
+        setCurrentField,
+      }}
+    >
+      {children}
+    </FormEditorContext.Provider>
+  );
+}
+
+export function useFormEditor() {
+  const context = useContext(FormEditorContext);
+  if (context === undefined) {
+    throw new Error("useFormEditor must be used within a FormEditorProvider");
+  }
+  return context;
+}
+
+export const FORM_EDITOR_SECTIONS_ENUMS = {
+  landingScreen: "landing-screen" as const,
+  questionsScreen: "questions-screen" as const,
+  endingScreen: "ending-screen" as const,
+  customizePage: "customize-page" as const,
+};
+
+export const defaultFormEditorSection =
+  FORM_EDITOR_SECTIONS_ENUMS.landingScreen as FormEditorSections;
+
+export type FormEditorSections =
+  (typeof FORM_EDITOR_SECTIONS_ENUMS)[keyof typeof FORM_EDITOR_SECTIONS_ENUMS];

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/layout.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { FormEditorPageHeader } from "@/app/(protectedPage)/forms/[formId]/_components/formPageHeader";
 import { getOrganizationId } from "@/lib/getOrganizationId";
 import { api } from "@/trpc/server";
+import { FormEditorProvider } from "./_components/formEditorContext";
 import NotFound from "./not-found";
 
 type Props = {
@@ -26,9 +27,11 @@ export default async function Layout({
     return <NotFound />;
   }
   return (
-    <div className="relative flex h-screen flex-col gap-3 ">
-      <FormEditorPageHeader formId={formId} />
-      <div className="grow">{children}</div>
-    </div>
+    <FormEditorProvider>
+      <div className="relative flex h-screen flex-col gap-3 ">
+        <FormEditorPageHeader formId={formId} />
+        <div className="grow">{children}</div>
+      </div>
+    </FormEditorProvider>
   );
 }

--- a/apps/web/src/app/(protectedPage)/forms/[formId]/page.tsx
+++ b/apps/web/src/app/(protectedPage)/forms/[formId]/page.tsx
@@ -10,6 +10,7 @@ import {
 import FormPreviewBrowser from "@/app/(protectedPage)/forms/[formId]/_components/formEditor/formPreviewBrowser";
 import MainNavTab from "@/app/(protectedPage)/forms/[formId]/_components/mainNavTab";
 import { api } from "@/trpc/react";
+import { FormCustomizeSection } from "./_components/formCustomizeSection";
 import { FormPublishToggle } from "./_components/formPublishToggle";
 import NotFound from "./not-found";
 
@@ -38,6 +39,7 @@ export default function FormPage({ params: { formId } }: Props) {
 
   return (
     <div className="h-full flex">
+      {/* Form editor section */}
       <div className=" flex flex-col space-y-2 px-5 max-h-[calc(100vh-100px)] w-[400px] min-w-[400px] overflow-auto">
         <MainNavTab formId={formId} />
         <Card className="relative flex-grow overflow-auto border-0 bg-transparent shadow-none">
@@ -51,10 +53,15 @@ export default function FormPage({ params: { formId } }: Props) {
           <FormPublishToggle form={data} />
         </div>
       </div>
+      {/* Form preview section */}
       <div className="flex grow items-center justify-center py-3 ">
         <div className="h-[100%] w-full pr-3">
           <FormPreviewBrowser formId={formId} />
         </div>
+      </div>
+      {/* Form customize section */}
+      <div className="w-[400px] min-w-[400px] py-3">
+        <FormCustomizeSection />
       </div>
     </div>
   );


### PR DESCRIPTION
✅ Closes: 364

### Description
Split the editor page into three area:

Left: Content editor
Middle: Form preview
Right: Design editor

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/4b72e99c-a2a7-49ce-9957-b571339e4987)


✅ Closes: #<issue_number>
